### PR TITLE
Don't differentiate through _opnormInf

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialAction"
 uuid = "e24c0720-ea99-47e8-929e-571b494574d3"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/util.jl
+++ b/src/util.jl
@@ -2,6 +2,9 @@
 _opnormInf(B) = opnorm(B, Inf)
 _opnormInf(B::AbstractVector) = norm(B, Inf)
 
+# we only use _opnormInf for control flow, so avoid differentiating through it
+ChainRulesCore.@non_differentiable _opnormInf(B)
+
 # TODO: replace with estimate
 # see https://github.com/JuliaLang/julia/pull/39058
 opnormest1(A) = opnorm(A, 1)

--- a/test/util.jl
+++ b/test/util.jl
@@ -14,7 +14,7 @@ using ExponentialAction, ChainRulesCore, LinearAlgebra, Test
         A = randn(ComplexF64, 10)
         n, back = ChainRulesCore.rrule(ExponentialAction._opnormInf, A)
         @test n == ExponentialAction._opnormInf(A)
-        @test @inferred(back(1.0)) === (NO_FIELDS, DoesNotExist())
+        @test @inferred(back(1.0)) === (DoesNotExist(), DoesNotExist())
         A = randn(ComplexF64, 10, 10)
         n, back = ChainRulesCore.rrule(ExponentialAction._opnormInf, A)
         @test n == ExponentialAction._opnormInf(A)

--- a/test/util.jl
+++ b/test/util.jl
@@ -18,7 +18,7 @@ using ExponentialAction, ChainRulesCore, LinearAlgebra, Test
         A = randn(ComplexF64, 10, 10)
         n, back = ChainRulesCore.rrule(ExponentialAction._opnormInf, A)
         @test n == ExponentialAction._opnormInf(A)
-        @test @inferred(back(1.0)) === (NO_FIELDS, DoesNotExist())
+        @test @inferred(back(1.0)) === (DoesNotExist(), DoesNotExist())
     end
 
     @testset "opnormest1" begin

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,4 +1,4 @@
-using ExponentialAction, LinearAlgebra, Test
+using ExponentialAction, ChainRulesCore, LinearAlgebra, Test
 
 @testset "Utilities" begin
     @testset "_opnormInf" begin
@@ -8,6 +8,17 @@ using ExponentialAction, LinearAlgebra, Test
         @test ExponentialAction._opnormInf(A) ≈ norm(A, Inf)
         A = randn(ComplexF64, 10, 10)
         @test ExponentialAction._opnormInf(A) ≈ opnorm(A, Inf)
+    end
+
+    @testset "_opnormInf non-differentiable" begin
+        A = randn(ComplexF64, 10)
+        n, back = ChainRulesCore.rrule(ExponentialAction._opnormInf, A)
+        @test n == ExponentialAction._opnormInf(A)
+        @test @inferred(back(1.0)) === (NO_FIELDS, DoesNotExist())
+        A = randn(ComplexF64, 10, 10)
+        n, back = ChainRulesCore.rrule(ExponentialAction._opnormInf, A)
+        @test n == ExponentialAction._opnormInf(A)
+        @test @inferred(back(1.0)) === (NO_FIELDS, DoesNotExist())
     end
 
     @testset "opnormest1" begin


### PR DESCRIPTION
Because `_opnormInf` is only used for control flow, we want to avoid tracing it at all if possible.  This PR marks it as non-differentiable for ChainRules-compatible ADs.