### PR TITLE
Increase clarity of code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,9 +21,10 @@ julia = "1"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ChainRulesTestUtils", "FiniteDifferences", "ForwardDiff", "ReverseDiff", "Test", "Zygote"]
+test = ["ChainRulesTestUtils", "FiniteDifferences", "ForwardDiff", "Random", "ReverseDiff", "Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,14 @@
 name = "ExponentialAction"
 uuid = "e24c0720-ea99-47e8-929e-571b494574d3"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialAction"
 uuid = "e24c0720-ea99-47e8-929e-571b494574d3"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialAction"
 uuid = "e24c0720-ea99-47e8-929e-571b494574d3"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,7 @@ version = "0.1.5"
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.1.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 ChainRulesCore = "0.9.7, 1"
 ChainRulesTestUtils = "0.7, 1"
+Compat = "3.31.1"
 julia = "1"
 
 [extras]

--- a/src/ExponentialAction.jl
+++ b/src/ExponentialAction.jl
@@ -3,6 +3,7 @@ module ExponentialAction
 using LinearAlgebra
 using ChainRulesCore: ChainRulesCore
 using SparseArrays: sparse
+using Compat: findmin
 
 include("util.jl")
 include("coefficients.jl")

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -20,7 +20,7 @@ The algorithm is described in [^AlMohyHigham2011].
     doi: [10.1137/100788860](https://doi.org/10.1137/100788860)
     eprint: [eprints.maths.manchester.ac.uk/id/eprint/1591](http://eprints.maths.manchester.ac.uk/id/eprint/1591)
 """
-function expv(t, A, B; shift=true, tol=eps(float(real(Base.promote_eltype(t, A, B)))))
+function expv(t, A, B; shift=true, tol=default_tolerance(t, A, B))
     n = LinearAlgebra.checksquare(A)
     # §3: “Our experience indicates that p_max = 8 and m_max = 55 are appropriate choices.”
     p_max = 8

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -4,7 +4,17 @@
 Compute `exp(t*A) * B` without computing `t * A` or the matrix exponential.
 This is significantly faster than the matrix exponential when the second dimension of `B` is
 much smaller than the first one. The "time" `t` may be real or complex.
-The algorithm is described in [^AlMohyHigham2011].
+
+In short, the approach computes
+```math
+F = \\left(\\prod_{i=1}^s T_m(tA / s)\\right) * B,
+```
+where ``T_m(X)`` is the Taylor series of `\\exp(X)` truncated to degree ``m = m^*``.
+The term ``s`` determines how many times the Taylor series acts on ``B``.
+``m^*`` and ``s`` are chosen to minimize the number of matrix products needed while
+maintaining the required tolerance.
+
+The algorithm is described in detail in Algorithm 3.2 in [^AlMohyHigham2011].
 
 # Keywords
 

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -32,16 +32,17 @@ function expv(t, A, B; shift=true, tol=default_tolerance(t, A, B))
     η = exp(t * μ / scale)  # term for undoing shifting
     F = one(η) * B
     for i in 1:scale
-        c1 = _opnormInf(B)
+        norm_tail_old = _opnormInf(B)
         # compute F ← exp(t A / scale) * F
         # let Zᵢ = Z
         for j in 1:degree_opt  # use Taylor series of exp(t A / scale)
-            B = (A * B) * (t / (scale * j))
-            c2 = _opnormInf(B)
+            B = (A * B) * (t / (scale * j))  # (t A)^j/j! * Zᵢ
+            norm_tail = _opnormInf(B)
             F += B
-            norm_tail = c1 + c2
+            # check if ratio of norm of tail and norm of series is below tolerance
+            norm_tail = norm_tail_old + norm_tail
             norm_tail ≤ tol * _opnormInf(F) && break
-            c1 = c2
+            norm_tail_old = norm_tail
         end
         F *= η
         B = F

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -30,22 +30,23 @@ function expv(t, A, B; shift=true, tol=default_tolerance(t, A, B))
     end
     degree_opt, scale = parameters(t, A, size(B, 2); tol=tol)  # m*, s
     η = exp(t * μ / scale)  # term for undoing shifting
-    F = one(η) * B
+    F = one(η) * Z
+    Z = B
     for i in 1:scale
-        norm_tail_old = _opnormInf(B)
+        norm_tail_old = _opnormInf(Z)
         # compute F ← exp(t A / scale) * F
         # let Zᵢ = Z
         for j in 1:degree_opt  # use Taylor series of exp(t A / scale)
-            B = (A * B) * (t / (scale * j))  # (t A)^j/j! * Zᵢ
-            norm_tail = _opnormInf(B)
-            F += B
+            Z = (A * Z) * (t / (scale * j))  # (t A)^j/j! * Zᵢ
+            norm_tail = _opnormInf(Z)
+            F += Z
             # check if ratio of norm of tail and norm of series is below tolerance
             norm_tail = norm_tail_old + norm_tail
             norm_tail ≤ tol * _opnormInf(F) && break
             norm_tail_old = norm_tail
         end
         F *= η
-        B = F
+        Z = F
     end
     return F
 end

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -41,12 +41,12 @@ function expv(t, A, B; shift=true, tol=default_tol(t, A, B))
     else
         μ = zero(float(eltype(A)))
     end
-    degree_opt, scale = parameters(t, A, size(B, 2); tol=tol)  # m*, s
+    degree_opt, scale = parameters(t, A, size(B, 2); tol)  # m*, s
     τ = t * one(μ) / scale
     η = exp(τ * μ)  # term for undoing shifting
     F = one(η) * B
     for _ in 1:scale
-        F = expv_taylor(τ, A, F, degree_opt; tol=tol)
+        F = expv_taylor(τ, A, F, degree_opt; tol)
         F *= η
     end
     return F

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -31,13 +31,16 @@ function expv(t, A, B; shift=true, tol=default_tolerance(t, A, B))
     degree_opt, scale = parameters(t, A, size(B, 2); tol=tol)  # m*, s
     η = exp(t * μ / scale)  # term for undoing shifting
     F = one(η) * B
-    for i in 1:(params.s)
+    for i in 1:scale
         c1 = _opnormInf(B)
-        for j in 1:(params.m)
-            B = (A * B) * (t / (params.s * j))
+        # compute F ← exp(t A / scale) * F
+        # let Zᵢ = Z
+        for j in 1:degree_opt  # use Taylor series of exp(t A / scale)
+            B = (A * B) * (t / (scale * j))
             c2 = _opnormInf(B)
             F += B
-            c1 + c2 ≤ tol * _opnormInf(F) && break
+            norm_tail = c1 + c2
+            norm_tail ≤ tol * _opnormInf(F) && break
             c1 = c2
         end
         F *= η

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -22,18 +22,14 @@ The algorithm is described in [^AlMohyHigham2011].
 """
 function expv(t, A, B; shift=true, tol=default_tolerance(t, A, B))
     n = LinearAlgebra.checksquare(A)
-    # §3: “Our experience indicates that p_max = 8 and m_max = 55 are appropriate choices.”
-    p_max = 8
-    m_max = 55
-    n0 = size(B, 2)
     if shift
         μ = tr(A) / n
         A -= μ * I
     else
         μ = zero(float(eltype(A)))
     end
-    params = parameters(t, A, n0, m_max, p_max, tol)
-    η = exp(t * μ / params.s)
+    degree_opt, scale = parameters(t, A, size(B, 2); tol=tol)  # m*, s
+    η = exp(t * μ / scale)  # term for undoing shifting
     F = one(η) * B
     for i in 1:(params.s)
         c1 = _opnormInf(B)

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -51,9 +51,10 @@ end
 expv(t, A::Diagonal, B; kwargs...) = exp.(t .* A.diag) .* B
 
 function expv_taylor(t, A, B, degree_opt; tol=default_tol(t, A, B))
+function expv_taylor(t, A, B, degree_max; tol=default_tol(t, A, B))
     F = Z = B
     norm_tail_old = _opnormInf(Z)
-    for j in 1:degree_opt
+    for j in 1:degree_max
         Z = (A * Z) * (t / j)  # (t A)ʲ/j! * B
         norm_tail = _opnormInf(Z)
         F += Z

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -1,5 +1,5 @@
 """
-    expv(t, A, B; kwargs...)
+    expv(t, A, B; shift=true, tol)
 
 Compute `exp(t*A) * B` without computing `t * A` or the matrix exponential.
 This is significantly faster than the matrix exponential when the second dimension of `B` is
@@ -7,12 +7,12 @@ much smaller than the first one. The "time" `t` may be real or complex.
 
 In short, the approach computes
 ```math
-F = \\left(\\prod_{i=1}^s T_m(tA / s)\\right) * B,
+F = \\left(\\prod_{i=1}^s T_m(tA / s)\\right) B,
 ```
 where ``T_m(X)`` is the Taylor series of `\\exp(X)` truncated to degree ``m = m^*``.
 The term ``s`` determines how many times the Taylor series acts on ``B``.
 ``m^*`` and ``s`` are chosen to minimize the number of matrix products needed while
-maintaining the required tolerance.
+maintaining the required tolerance `tol`.
 
 The algorithm is described in detail in Algorithm 3.2 in [^AlMohyHigham2011].
 
@@ -21,10 +21,11 @@ The algorithm is described in detail in Algorithm 3.2 in [^AlMohyHigham2011].
   - `shift=true`: Expand the Taylor series of `exp(t*A)` about ``A-μI=0`` instead of
     ``A=0``, where ``μ = \\operatorname{tr}(A) / n`` to speed up convergence. See
     §3.1 of [^AlMohyHigham2011].
-  - `tol`: The tolerance at which to compute the result. Defaults to the tolerance of the
-    eltype of the result.
+  - `tol`: The relative tolerance at which to compute the result. Defaults to the tolerance
+    of the eltype of the result.
 
-[^AlMohyHigham2011]: Al-Mohy, Awad H. and Higham, Nicholas J. (2011) Computing the Action of the Matrix
+[^AlMohyHigham2011]: Al-Mohy, Awad H. and Higham, Nicholas J. (2011)
+    Computing the Action of the Matrix
     Exponential, with an Application to Exponential Integrators. SIAM Journal on Scientific
     Computing, 33 (2). pp. 488-511. ISSN 1064-8275
     doi: [10.1137/100788860](https://doi.org/10.1137/100788860)
@@ -50,7 +51,21 @@ function expv(t, A, B; shift=true, tol=default_tol(t, A, B))
 end
 expv(t, A::Diagonal, B; kwargs...) = exp.(t .* A.diag) .* B
 
-function expv_taylor(t, A, B, degree_opt; tol=default_tol(t, A, B))
+"""
+    expv_taylor(t, A, B, degree_max; tol)
+
+Compute `exp(t*A)*B` using the truncated Taylor series with degree ``m=`` `degree_max`.
+
+Instead of computing the Taylor series ``T_m(tA)`` of the matrix exponential directly, its
+action on `B` is computed instead.
+
+The series is truncated early if
+```math
+\\frac{\\lVert \\exp(t A) B - T_m(tA) B \\rVert_1}{\\lVert T_m(tA) B \\rVert_1} \\le \\mathrm{tol},
+```
+where ``\\lVert X \\rVert_1`` is the operator 1-norm of the matrix ``X``.
+This condition is only approximately checked.
+"""
 function expv_taylor(t, A, B, degree_max; tol=default_tol(t, A, B))
     F = Z = B
     norm_tail_old = _opnormInf(Z)

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -39,25 +39,28 @@ function expv(t, A, B; shift=true, tol=default_tolerance(t, A, B))
         μ = zero(float(eltype(A)))
     end
     degree_opt, scale = parameters(t, A, size(B, 2); tol=tol)  # m*, s
-    η = exp(t * μ / scale)  # term for undoing shifting
-    F = one(η) * Z
-    Z = B
-    for i in 1:scale
-        norm_tail_old = _opnormInf(Z)
-        # compute F ← exp(t A / scale) * F
-        # let Zᵢ = Z
-        for j in 1:degree_opt  # use Taylor series of exp(t A / scale)
-            Z = (A * Z) * (t / (scale * j))  # (t A)^j/j! * Zᵢ
-            norm_tail = _opnormInf(Z)
-            F += Z
-            # check if ratio of norm of tail and norm of series is below tolerance
-            norm_tail = norm_tail_old + norm_tail
-            norm_tail ≤ tol * _opnormInf(F) && break
-            norm_tail_old = norm_tail
-        end
+    τ = t * one(μ) / scale
+    η = exp(τ * μ)  # term for undoing shifting
+    F = one(η) * B
+    for _ in 1:scale
+        F = expv_taylor(τ, A, F, degree_opt; tol=tol)
         F *= η
-        Z = F
     end
     return F
 end
 expv(t, A::Diagonal, B; kwargs...) = exp.(t .* A.diag) .* B
+
+function expv_taylor(t, A, B, degree_opt; tol=default_tolerance(t, A, B))
+    F = Z = B
+    norm_tail_old = _opnormInf(Z)
+    for j in 1:degree_opt
+        Z = (A * Z) * (t / j)  # (t A)ʲ/j! * B
+        norm_tail = _opnormInf(Z)
+        F += Z
+        # check if ratio of norm of tail and norm of series is below tolerance
+        norm_tail = norm_tail_old + norm_tail
+        norm_tail ≤ tol * _opnormInf(F) && break
+        norm_tail_old = norm_tail
+    end
+    return F
+end

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -6,9 +6,11 @@ This is significantly faster than the matrix exponential when the second dimensi
 much smaller than the first one. The "time" `t` may be real or complex.
 
 In short, the approach computes
+
 ```math
 F = \\left(\\prod_{i=1}^s T_m(tA / s)\\right) B,
 ```
+
 where ``T_m(X)`` is the Taylor series of `\\exp(X)` truncated to degree ``m = m^*``.
 The term ``s`` determines how many times the Taylor series acts on ``B``.
 ``m^*`` and ``s`` are chosen to minimize the number of matrix products needed while
@@ -60,9 +62,11 @@ Instead of computing the Taylor series ``T_m(tA)`` of the matrix exponential dir
 action on `B` is computed instead.
 
 The series is truncated early if
+
 ```math
 \\frac{\\lVert \\exp(t A) B - T_m(tA) B \\rVert_1}{\\lVert T_m(tA) B \\rVert_1} \\le \\mathrm{tol},
 ```
+
 where ``\\lVert X \\rVert_1`` is the operator 1-norm of the matrix ``X``.
 This condition is only approximately checked.
 """

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -6,17 +6,20 @@ Compute Taylor series parameters needed for ``\\exp(t*A) * B``.
 This is Code Fragment 3.1 from [^AlMohyHigham2011].
 
 # Keywords
-- `tol`: the desired relative tolerance
-- `degree_max=55`: the maximum degree of the truncated Taylor series that will be used. This
-  is ``m_{\\mathrm{max}}`` in [^AlMohyHigham2011], where they recommend a value of 55 in §3.
-- `ℓ=2`: the number of columns in the matrix that is multiplied for norm estimation (note:
-  currently only used for control flow.). Recommended values are 1 or 2.
+
+  - `tol`: the desired relative tolerance
+  - `degree_max=55`: the maximum degree of the truncated Taylor series that will be used.
+    This is ``m_{\\mathrm{max}}`` in [^AlMohyHigham2011], where they recommend a value of 55
+    in §3.
+  - `ℓ=2`: the number of columns in the matrix that is multiplied for norm estimation (note:
+    currently only used for control flow.). Recommended values are 1 or 2.
 
 # Returns
-- `degree_opt`: the degree of the truncated Taylor series that will be used. This is
-  ``m^*`` in [^AlMohyHigham2011],
-- `scale`: the amount of scaling ``s`` that will be applied to ``A``. The truncated Taylor
-  series of ``\\exp(t A / s)`` will be applied ``s`` times to ``B``.
+
+  - `degree_opt`: the degree of the truncated Taylor series that will be used. This is
+    ``m^*`` in [^AlMohyHigham2011],
+  - `scale`: the amount of scaling ``s`` that will be applied to ``A``. The truncated Taylor
+    series of ``\\exp(t A / s)`` will be applied ``s`` times to ``B``.
 """
 function parameters(t, A, ncols_B; tol=default_tol(t, A), degree_max::Int=55, ℓ::Int=2)
     return _parameters(AD.primal_value(t), AD.primal_value(A), ncols_B, degree_max, ℓ, tol)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,9 +1,22 @@
 """
     parameters(t, A, ncols_B; kwargs...) -> (degree_opt, scale)
 
-Compute Taylor series parameters needed for `exp(t*A) * B`.
+Compute Taylor series parameters needed for ``\\exp(t*A) * B``.
 
 This is Code Fragment 3.1 from [^AlMohyHigham2011].
+
+# Keywords
+- `tol`: the desired tolerance
+- `degree_max=55`: the maximum degree of the truncated Taylor series that will be used. This
+  is ``m_{\\mathrm{max}}`` in [^AlMohyHigham2011], where they recommend a value of 55 in §3.
+- `ℓ=2`: the number of columns in the matrix that is multiplied for norm estimation (note:
+  currently only used for control flow.). Recommended values are 1 or 2.
+
+# Returns
+- `degree_opt`: the degree of the truncated Taylor series that will be used. This is
+  ``m^*`` in [^AlMohyHigham2011],
+- `scale`: the amount of scaling ``s`` that will be applied to ``A``. The truncated Taylor
+  series of ``\\exp(t A / s)`` will be applied ``s`` times to ``B``.
 """
 function parameters(t, A, ncols_B; tol=default_tolerance(t, A), degree_max::Int=55, ℓ::Int=2)
     t_norm = abs(t)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -6,7 +6,7 @@ Compute Taylor series parameters needed for ``\\exp(t*A) * B``.
 This is Code Fragment 3.1 from [^AlMohyHigham2011].
 
 # Keywords
-- `tol`: the desired tolerance
+- `tol`: the desired relative tolerance
 - `degree_max=55`: the maximum degree of the truncated Taylor series that will be used. This
   is ``m_{\\mathrm{max}}`` in [^AlMohyHigham2011], where they recommend a value of 55 in §3.
 - `ℓ=2`: the number of columns in the matrix that is multiplied for norm estimation (note:

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -18,7 +18,9 @@ This is Code Fragment 3.1 from [^AlMohyHigham2011].
 - `scale`: the amount of scaling ``s`` that will be applied to ``A``. The truncated Taylor
   series of ``\\exp(t A / s)`` will be applied ``s`` times to ``B``.
 """
-function parameters(t, A, ncols_B; tol=default_tolerance(t, A), degree_max::Int=55, ℓ::Int=2)
+function parameters(
+    t, A, ncols_B; tol=default_tolerance(t, A), degree_max::Int=55, ℓ::Int=2
+)
     t_norm = abs(t)
     iszero(t_norm) && return (0, 1)
     Anorm = opnormest1(A)
@@ -48,7 +50,8 @@ function parameters(t, A, ncols_B; tol=default_tolerance(t, A), degree_max::Int=
             degree_min = p * (p - 1) - 1
             for degree in degree_min:degree_max
                 num_mat_mul = asint(degree * cld(α, θ[degree]))
-                if num_mat_mul < num_mat_mul_opt || (num_mat_mul == num_mat_mul_opt && degree < degree_opt)
+                if num_mat_mul < num_mat_mul_opt ||
+                    (num_mat_mul == num_mat_mul_opt && degree < degree_opt)
                     degree_opt = degree
                     num_mat_mul_opt = num_mat_mul
                 end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -72,8 +72,8 @@ function _parameters(t, A::Union{Bidiagonal,Tridiagonal}, ncols_B, degree_max, �
     return _parameters(t, sparse(A), ncols_B, degree_max, ℓ, tol)
 end
 
-# avoid differentiating through parameters with ChainRules-compatible ADs
-ChainRulesCore.@non_differentiable parameters(t, A, ncols_B)
+# avoid differentiating through _parameters with ChainRules-compatible ADs
+ChainRulesCore.@non_differentiable _parameters(t, A, ncols_B, degree_max, ℓ, tol)
 
 # solution p to p(p-1) ≤ m + 1
 p_from_degree_max(degree_max) = Int(fld(1 + sqrt(5 + 4 * degree_max), 2))

--- a/src/util.jl
+++ b/src/util.jl
@@ -8,3 +8,5 @@ ChainRulesCore.@non_differentiable _opnormInf(B)
 # TODO: replace with estimate
 # see https://github.com/JuliaLang/julia/pull/39058
 opnormest1(A) = opnorm(A, 1)
+
+asint(x) = x ≤ typemax(Int) ? Int(x) : typemax(Int)

--- a/src/util.jl
+++ b/src/util.jl
@@ -2,11 +2,14 @@
 _opnormInf(B) = opnorm(B, Inf)
 _opnormInf(B::AbstractVector) = norm(B, Inf)
 
-# we only use _opnormInf for control flow, so avoid differentiating through it
-ChainRulesCore.@non_differentiable _opnormInf(B)
-
 # TODO: replace with estimate
 # see https://github.com/JuliaLang/julia/pull/39058
 opnormest1(A) = opnorm(A, 1)
 
 asint(x) = x ≤ typemax(Int) ? Int(x) : typemax(Int)
+
+default_tolerance(args...) = eps(float(real(Base.promote_eltype(args...))))
+
+# we only use these for control flow, so avoid differentiating through them
+ChainRulesCore.@non_differentiable _opnormInf(B)
+ChainRulesCore.@non_differentiable default_tolerance(args...)

--- a/test/expv.jl
+++ b/test/expv.jl
@@ -3,6 +3,16 @@ using ExponentialAction, LinearAlgebra, SparseArrays, Test
 Tsingle = (Float32, ComplexF32)
 Tdouble = (Float64, ComplexF64)
 
+@testset "expv_taylor" begin
+    for i in 1:0.1:10
+        t = rand() * i
+        A = randn(5, 5)
+        A /= opnorm(A, 1)
+        B = randn(5, 2)
+        @test ExponentialAction.expv_taylor(t, A, B, 1_000) ≈ exp(t * A) * B
+    end
+end
+
 @testset "expv" begin
     n = 10
     @testset "expv(t::$Tt, A::$MT{$TA}, B::Array{$TB,$(length(Bdims2)+1)}), tscale=$tscale, shift=$shift" for MT in

--- a/test/expv.jl
+++ b/test/expv.jl
@@ -5,8 +5,10 @@ Tdouble = (Float64, ComplexF64)
 
 @testset "expv" begin
     n = 10
-    @testset "expv(t::$Tt, A::$MT{$TA}, B::Array{$TB,$(length(Bdims2)+1)}), tscale=$tscale, shift=$shift" for
-        MT in (Matrix, Diagonal, Bidiagonal, Tridiagonal),
+    @testset "expv(t::$Tt, A::$MT{$TA}, B::Array{$TB,$(length(Bdims2)+1)}), tscale=$tscale, shift=$shift" for MT in
+                                                                                                              (
+            Matrix, Diagonal, Bidiagonal, Tridiagonal
+        ),
         Tset in (Tsingle, Tdouble),
         Bdims2 in ((), (4,)),
         Tt in Tset,
@@ -29,8 +31,10 @@ Tdouble = (Float64, ComplexF64)
         @test eltype(expv(t, A, B; shift=shift)) === T
     end
 
-    @testset "expv(t::$Tt, A::SparseMatrixCSC{$TA}, B::Array{$TB,$(length(Bdims2)+1)}), tscale=$tscale, shift=$shift" for
-        Tset in (Tsingle, Tdouble),
+    @testset "expv(t::$Tt, A::SparseMatrixCSC{$TA}, B::Array{$TB,$(length(Bdims2)+1)}), tscale=$tscale, shift=$shift" for Tset in
+                                                                                                                          (
+            Tsingle, Tdouble
+        ),
         Bdims2 in ((), (4,)),
         Tt in Tset,
         TA in Tset,
@@ -60,11 +64,13 @@ Tdouble = (Float64, ComplexF64)
     @testset "no errors for high norm" begin
         # https://github.com/sethaxen/ExponentialAction.jl/issues/10
         t = 20.0
-        A = [-4.19   0.0     8.75   0.0   0.0;
-              0.0  -57.45   33.26   0.0   0.0;
-              0.0    0.0  -175.05   0.0   0.0;
-              4.19  57.45    0.0  -87.53  6.28;
-              0.0    0.0    13.13   0.0  -6.28]
+        A = [
+            -4.19 0.0 8.75 0.0 0.0
+            0.0 -57.45 33.26 0.0 0.0
+            0.0 0.0 -175.05 0.0 0.0
+            4.19 57.45 0.0 -87.53 6.28
+            0.0 0.0 13.13 0.0 -6.28
+        ]
         B = ones(size(A, 2))
         @test expv(t, A, B) ≈ exp(t * A) * B
     end

--- a/test/expv.jl
+++ b/test/expv.jl
@@ -74,13 +74,15 @@ end
     @testset "no errors for high norm" begin
         # https://github.com/sethaxen/ExponentialAction.jl/issues/10
         t = 20.0
-        A = [
-            -4.19 0.0 8.75 0.0 0.0
-            0.0 -57.45 33.26 0.0 0.0
-            0.0 0.0 -175.05 0.0 0.0
-            4.19 57.45 0.0 -87.53 6.28
-            0.0 0.0 13.13 0.0 -6.28
-        ]
+
+        #! format: off
+        A = [-4.19   0.0     8.75   0.0   0.0
+              0.0  -57.45   33.26   0.0   0.0
+              0.0    0.0  -175.05   0.0   0.0
+              4.19  57.45    0.0  -87.53  6.28
+              0.0    0.0    13.13   0.0  -6.28]
+        #! format: on
+
         B = ones(size(A, 2))
         @test expv(t, A, B) ≈ exp(t * A) * B
     end

--- a/test/expv.jl
+++ b/test/expv.jl
@@ -36,9 +36,9 @@ end
         B = randn(TB, n, Bdims2...)
         T = Base.promote_eltype(t, A, B)
         rT = real(T)
-        @inferred expv(t, A, B; shift=shift)
-        @test expv(t, A, B; shift=shift) ≈ exp(Matrix(t * A)) * B
-        @test eltype(expv(t, A, B; shift=shift)) === T
+        @inferred expv(t, A, B; shift)
+        @test expv(t, A, B; shift) ≈ exp(Matrix(t * A)) * B
+        @test eltype(expv(t, A, B; shift)) === T
     end
 
     @testset "expv(t::$Tt, A::SparseMatrixCSC{$TA}, B::Array{$TB,$(length(Bdims2)+1)}), tscale=$tscale, shift=$shift" for Tset in
@@ -57,9 +57,9 @@ end
         B = randn(TB, n, Bdims2...)
         T = Base.promote_eltype(t, A, B)
         rT = real(T)
-        @inferred expv(t, A, B; shift=shift)
-        @test expv(t, A, B; shift=shift) ≈ exp(Matrix(t * A)) * B
-        @test eltype(expv(t, A, B; shift=shift)) === T
+        @inferred expv(t, A, B; shift)
+        @test expv(t, A, B; shift) ≈ exp(Matrix(t * A)) * B
+        @test eltype(expv(t, A, B; shift)) === T
     end
 
     @testset "errors if tolerance too low" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using ExponentialAction
+using Random
 using Test
+
+Random.seed!(1)  # set seed used for all testsets
 
 @testset "ExponentialAction.jl" begin
     include("util.jl")

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,5 +1,5 @@
 using ExponentialAction, ChainRulesCore, ChainRulesTestUtils, LinearAlgebra, Test
-using ExponentialAction: _opnormInf, asint
+using ExponentialAction: _opnormInf
 
 @testset "Utilities" begin
     @testset "_opnormInf" begin
@@ -21,7 +21,15 @@ using ExponentialAction: _opnormInf, asint
     end
 
     @testset "asint" begin
-        @test asint(float(typemax(Int)*10)) == typemax(Int)
-        @test asint(37.0)) == 37
+        @test ExponentialAction.asint(float(typemax(Int)*10)) == typemax(Int)
+        @test ExponentialAction.asint(37.0)) == 37
+    end
+
+    @testset "default_tolerance" begin
+        @test ExponentialAction.default_tolerance(randn()) ≈ eps(Float64)
+        @test ExponentialAction.default_tolerance(randn(ComplexF64)) ≈ eps(Float64)
+        @test ExponentialAction.default_tolerance(randn(Float32)) ≈ eps(Float32)
+        @test ExponentialAction.default_tolerance(1, randn()) ≈ eps(Float64)
+        test_rrule(ExponentialAction.default_tolerance, randn() ⊢ NoTangent(); atol=1e-6)
     end
 end

--- a/test/util.jl
+++ b/test/util.jl
@@ -21,8 +21,8 @@ using ExponentialAction: _opnormInf
     end
 
     @testset "asint" begin
-        @test ExponentialAction.asint(float(typemax(Int)*10)) == typemax(Int)
-        @test ExponentialAction.asint(37.0)) == 37
+        @test ExponentialAction.asint(float(typemax(Int) * 10)) == typemax(Int)
+        @test ExponentialAction.asint(37.0) == 37
     end
 
     @testset "default_tolerance" begin

--- a/test/util.jl
+++ b/test/util.jl
@@ -21,7 +21,7 @@ using ExponentialAction: _opnormInf
     end
 
     @testset "asint" begin
-        @test ExponentialAction.asint(float(typemax(Int) * 10)) == typemax(Int)
+        @test ExponentialAction.asint(float(typemax(Int))) == typemax(Int)
         @test ExponentialAction.asint(37.0) == 37
     end
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,5 +1,5 @@
 using ExponentialAction, ChainRulesCore, ChainRulesTestUtils, LinearAlgebra, Test
-using ExponentialAction: _opnormInf
+using ExponentialAction: _opnormInf, asint
 
 @testset "Utilities" begin
     @testset "_opnormInf" begin
@@ -18,5 +18,10 @@ using ExponentialAction: _opnormInf
     @testset "opnormest1" begin
         A = randn(ComplexF64, 10, 10)
         @test ExponentialAction.opnormest1(A) ≈ opnorm(A, 1)
+    end
+
+    @testset "asint" begin
+        @test asint(float(typemax(Int)*10)) == typemax(Int)
+        @test asint(37.0)) == 37
     end
 end


### PR DESCRIPTION
This PR increases the clarity of the code. In particular, it replaces the terse symbols like `s` and `m` used in the paper with more descriptive variable names, along with comments and docstrings to explain the algorithmic steps. These improvements will make it easier to implement new features.

This PR is currently blocked by https://github.com/JuliaDiff/ReverseDiff.jl/pull/198 and https://github.com/JuliaDiff/ForwardDiff.jl/pull/581