### PR TITLE
Speed up control flow for operator-overloading ADs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialAction"
 uuid = "e24c0720-ea99-47e8-929e-571b494574d3"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
 version = "0.1.4"
 
 [deps]
+AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+AbstractDifferentiation = "0.4"
 ChainRulesCore = "0.9.7, 1"
 ChainRulesTestUtils = "0.7, 1"
 julia = "1"

--- a/src/ExponentialAction.jl
+++ b/src/ExponentialAction.jl
@@ -3,6 +3,7 @@ module ExponentialAction
 using LinearAlgebra
 using ChainRulesCore: ChainRulesCore
 using SparseArrays: sparse
+using AbstractDifferentiation: AD
 
 include("util.jl")
 include("coefficients.jl")

--- a/src/expv.jl
+++ b/src/expv.jl
@@ -20,7 +20,7 @@ The algorithm is described in [^AlMohyHigham2011].
     doi: [10.1137/100788860](https://doi.org/10.1137/100788860)
     eprint: [eprints.maths.manchester.ac.uk/id/eprint/1591](http://eprints.maths.manchester.ac.uk/id/eprint/1591)
 """
-function expv(t, A, B; shift=true, tol=eps(float(real(Base.promote_eltype(t, A, B)))))
+function expv(t, A, B; shift=true, tol=default_tol(t, A, B))
     n = LinearAlgebra.checksquare(A)
     # §3: “Our experience indicates that p_max = 8 and m_max = 55 are appropriate choices.”
     p_max = 8

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -5,9 +5,7 @@ Compute Taylor series parameters needed for `exp(t*A) * B`.
 
 This is Code Fragment 3.1 from [^AlMohyHigham2011].
 """
-function parameters(
-    t, A, n0, m_max, p_max=p_from_m(m_max), tol=eps(float(real(Base.promote_eltype(t, A))))
-)
+function parameters(t, A, n0, m_max, p_max=p_from_m(m_max), tol=default_tol(t, A))
     tnorm = abs(t)
     iszero(tnorm) && return (m=0, s=1)
     Anorm = opnormest1(A)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -24,13 +24,13 @@ function _parameters(t, A, n0, m_max, p_max, tol)
         Cm_opt = T(Inf)
         # work around argmin not taking a function
         for m in 1:m_max
-            Cm = m * T(ceil(tAnorm / θ[m]))
+            Cm = m * T(cld(tAnorm, θ[m]))
             if Cm < Cm_opt
                 m_opt = m
                 Cm_opt = Cm
             end
         end
-        s = ceil(Int, Cm_opt / m_opt)
+        s = Int(cld(Cm_opt, m_opt))
     else
         # TODO: replace powers of A here and below with opnormest(pow, A, 1)
         # see https://github.com/JuliaLang/julia/pull/39058
@@ -46,21 +46,21 @@ function _parameters(t, A, n0, m_max, p_max, tol)
             m_min = p * (p - 1) - 1
             # work around argmin not taking a function
             for m in m_min:m_max
-                Cm = m * T(ceil(α / θ[m]))
+                Cm = m * T(cld(α, θ[m]))
                 if Cm < Cm_opt || (Cm == Cm_opt && m < m_opt)
                     m_opt = m
                     Cm_opt = Cm
                 end
             end
         end
-        s = max(ceil(Int, Cm_opt / m_opt), 1)
+        s = max(Int(cld(Cm_opt, m_opt)), 1)
     end
     return (m=m_opt, s=s)
 end
 # work around opnorm(A, 1) and (A^2)*A having very slow defaults for these arrays
 # https://github.com/sethaxen/ExponentialAction.jl/issues/3
 function _parameters(t, A::Union{Bidiagonal,Tridiagonal}, n0, m_max, p_max, tol)
-    return parameters(t, sparse(A), n0, m_max, p_max, tol)
+    return _parameters(t, sparse(A), n0, m_max, p_max, tol)
 end
 
 # avoid differentiating through parameters with ChainRules-compatible ADs

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -6,6 +6,11 @@ Compute Taylor series parameters needed for `exp(t*A) * B`.
 This is Code Fragment 3.1 from [^AlMohyHigham2011].
 """
 function parameters(t, A, n0, m_max, p_max=p_from_m(m_max), tol=default_tol(t, A))
+    # avoid operator-overloading ADs differentiating through the function
+    return _parameters(AD.primal_value(t), AD.primal_value(A), n0, m_max, p_max, tol)
+end
+
+function _parameters(t, A, n0, m_max, p_max, tol)
     tnorm = abs(t)
     iszero(tnorm) && return (m=0, s=1)
     Anorm = opnormest1(A)
@@ -54,14 +59,7 @@ function parameters(t, A, n0, m_max, p_max=p_from_m(m_max), tol=default_tol(t, A
 end
 # work around opnorm(A, 1) and (A^2)*A having very slow defaults for these arrays
 # https://github.com/sethaxen/ExponentialAction.jl/issues/3
-function parameters(
-    t,
-    A::Union{Bidiagonal,Tridiagonal},
-    n0,
-    m_max,
-    p_max=p_from_m(m_max),
-    tol=eps(float(real(Base.promote_eltype(t, A)))),
-)
+function _parameters(t, A::Union{Bidiagonal,Tridiagonal}, n0, m_max, p_max, tol)
     return parameters(t, sparse(A), n0, m_max, p_max, tol)
 end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,6 +1,6 @@
 # workaround for opnorm(::AbstractVector, Inf) not being implemented
-_opnormInf(B) = opnorm(B, Inf)
-_opnormInf(B::AbstractVector) = norm(B, Inf)
+_opnormInf(B) = opnorm(AD.primal_value(B), Inf)
+_opnormInf(B::AbstractVector) = norm(AD.primal_value(B), Inf)
 
 # we only use _opnormInf for control flow, so avoid differentiating through it
 ChainRulesCore.@non_differentiable _opnormInf(B)

--- a/src/util.jl
+++ b/src/util.jl
@@ -8,3 +8,7 @@ ChainRulesCore.@non_differentiable _opnormInf(B)
 # TODO: replace with estimate
 # see https://github.com/JuliaLang/julia/pull/39058
 opnormest1(A) = opnorm(A, 1)
+
+default_tol(args...) = AD.primal_value(eps(float(real(Base.promote_eltype(args...)))))
+
+ChainRulesCore.@non_differentiable default_tol(args...)

--- a/test/util.jl
+++ b/test/util.jl
@@ -19,4 +19,12 @@ using ExponentialAction: _opnormInf
         A = randn(ComplexF64, 10, 10)
         @test ExponentialAction.opnormest1(A) ≈ opnorm(A, 1)
     end
+
+    @testset "default_tol" begin
+        @test ExponentialAction.default_tol(randn()) ≈ eps(Float64)
+        @test ExponentialAction.default_tol(randn(ComplexF64)) ≈ eps(Float64)
+        @test ExponentialAction.default_tol(randn(Float32)) ≈ eps(Float32)
+        @test ExponentialAction.default_tol(1, randn()) ≈ eps(Float64)
+        test_rrule(ExponentialAction.default_tol, randn() ⊢ NoTangent(); atol=1e-6)
+    end
 end


### PR DESCRIPTION
We already mark some functions that are only used for control flow as non-differentiable for ChainRules-compatible automatic differentiation packages. However, packages like ForwardDiff and ReverseDiff, which are operator-overloading ADs, still will differentiate through these functions, which is slow. `AbstractDifferentiation.primal_value` extracts just the value from one of these differential types, which prevents downstream AD from happening. In this PR, we use `primal_value` to speed up the control flow.

As a side effect, we no longer need to worry about using AD-friendly patterns within these functions.