### PR TITLE
Bump minimum supported Julia version to 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   push:
+    branches: [main]
+    tags: [v*]
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - 1
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 AbstractDifferentiation = "0.4"
 ChainRulesCore = "0.9.7, 1"
 ChainRulesTestUtils = "0.7, 1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialAction"
 uuid = "e24c0720-ea99-47e8-929e-571b494574d3"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.1.5"
+version = "0.2.0"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/test/expv.jl
+++ b/test/expv.jl
@@ -39,7 +39,7 @@ Tdouble = (Float64, ComplexF64)
         shift in (true, false)
 
         t = tscale * randn(Tt)
-        A = VERSION ≥ v"1.1" ? sprandn(TA, n, n, 1 / n) : TA.(sprandn(n, n, 1 / n))
+        A = sprandn(TA, n, n, 1 / n)
         B = randn(TB, n, Bdims2...)
         T = Base.promote_eltype(t, A, B)
         rT = real(T)


### PR DESCRIPTION
Because some AD packages only work correctly on more recent Julia versions, to really test against these packages, we need to only test more recent versions. Instead of claiming to support Julia versions that we don't test, this PR bumps the minimum Julia version to the LTS (~1 year old).

Here we also decrease the number of CI runs to in general only test on pull.