### PR TITLE
Add Enzyme compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,22 @@ version = "0.2.5"
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[weakdeps]
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+
+[extensions]
+ExponentialActionEnzymeCoreExt = "EnzymeCore"
 
 [compat]
 AbstractDifferentiation = "0.4, 0.5"
 ChainRulesCore = "0.9.7, 1"
 ChainRulesTestUtils = "0.7, 1"
 Compat = "3.31.1, 4"
+EnzymeCore = "0.3"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialAction"
 uuid = "e24c0720-ea99-47e8-929e-571b494574d3"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/ext/ExponentialActionEnzymeCoreExt.jl
+++ b/ext/ExponentialActionEnzymeCoreExt.jl
@@ -1,0 +1,11 @@
+module ExponentialActionEnzymeCoreExt
+
+using ExponentialAction: ExponentialAction
+using EnzymeCore: EnzymeRules
+
+EnzymeRules.inactive(::typeof(ExponentialAction._parameters), t, A, ncols_B, degree_max, ℓ, tol) = nothing
+EnzymeRules.inactive(::typeof(ExponentialAction._opnormInf), B) = nothing
+EnzymeRules.inactive(::typeof(ExponentialAction.default_tol), args...) = nothing
+EnzymeRules.inactive(::typeof(ExponentialAction.get_shift), A) = nothing
+
+end  # module

--- a/src/ExponentialAction.jl
+++ b/src/ExponentialAction.jl
@@ -22,6 +22,8 @@ include("taylor.jl")
 include("expv.jl")
 include("sequence.jl")
 
+isdefined(Base, :get_extension) || include("../ext/ExponentialActionEnzymeCoreExt.jl")
+
 export expv, expv_sequence
 
 end


### PR DESCRIPTION
This PR adds enzyme compatibility by marking as inactivate using EnzymeRules the numerical methods used only for control flow.

Since Enzyme supports mutation, a future PR could add mutating variants of `expv` and `expv_sequence`, which should then just work with Enzyme.

To test this using our current suite, an Enzyme backend needs to bee added to AbstractDifferentiation.