### PR TITLE
Fix typo in parameters computation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialAction"
 uuid = "e24c0720-ea99-47e8-929e-571b494574d3"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -51,7 +51,7 @@ function _parameters(t, A, ncols_B, degree_max, ℓ, tol)
         # TODO: replace powers of A here and below with opnormest(pow, A, 1)
         # see https://github.com/JuliaLang/julia/pull/39058
         Aᵖ⁺¹ = A * A
-        d = t_norm * sqrt(opnormest1(A))
+        d = t_norm * sqrt(opnormest1(Aᵖ⁺¹))
         degree_opt = degree_max + 1
         num_mat_mul_opt = typemax(Int)
         for p in 2:p_max # Compute minimum in (3.11)


### PR DESCRIPTION
This PR fixes the typo identified in  #28. No regression test is added since I haven't been able to find any arrays for which this caused the result to be inaccurate.