### PR TITLE
ci: remove no-commit-to-branch pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
-      - id: no-commit-to-branch
       - id: trailing-whitespace
   - repo: 'https://github.com/fredrikekre/runic-pre-commit'
     rev: v2.0.1


### PR DESCRIPTION
This hook checks the current git branch when a commit is made, intended to stop accidental local commits to a protected branch. It's not meaningful in CI: the "Code checks" workflow checks out main by name on every push-to-main, so the hook fails unconditionally regardless of diff content — every push-triggered run of this workflow has failed since the hook was added in #42.

Branch protection already requires PRs for this repo, so direct commits to main aren't possible anyway, making the hook redundant. Removing it.