### PR TITLE
ci: standardize Downgrade workflow

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1']
+        version: ['lts']
         os: ['ubuntu-latest']
     steps:
       - uses: actions/checkout@v7
@@ -25,6 +25,13 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
-          skip: LinearAlgebra,Random,SparseArrays,Test
+          mode: deps
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: false
+          force_latest_compatible_version: false
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v7
+        with:
+          files: lcov.info


### PR DESCRIPTION
- Track Julia \`lts\` instead of the runtime default
- Set \`mode: deps\` explicitly instead of a skip list
- Add coverage reporting and \`allow_reresolve\`/\`force_latest_compatible_version: false\` on runtest, matching the rest of the fleet