### PR TITLE
fix(expv_taylor): don't truncate the Taylor series when the primal is exactly zero

### DIFF
--- a/src/taylor.jl
+++ b/src/taylor.jl
@@ -24,7 +24,14 @@ function expv_taylor(t, A, B, degree_max; tol = default_tol(t, A, B))
         # check if ratio of norm of tail and norm of series is below tolerance
         norm_tail = _opnormInf(Z)
         norm_tail_tot = norm_tail_old + norm_tail
-        norm_tail_tot ≤ tol * _opnormInf(F) && break
+        # An exactly-zero primal norm makes the check degenerate (0 ≤ tol·0),
+        # which can arise with AD types whose primal is zero but whose partials
+        # are not (e.g. ForwardDiff Duals seeded at a zero state). Breaking
+        # there would silently truncate the dual part of the series, so treat
+        # a zero-primal series as not converged and keep iterating up to the
+        # chosen degree, which already bounds the tail by `tol`.
+        norm_F = _opnormInf(F)
+        !iszero(norm_tail_tot) && !iszero(norm_F) && norm_tail_tot ≤ tol * norm_F && break
         norm_tail_old = norm_tail
     end
     return F

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -122,3 +122,27 @@ end
         end
     end
 end
+
+@testset "expv dual at zero-primal B (issue #59)" begin
+    # The Taylor convergence check strips duals; with an exactly-zero-primal
+    # B carrying nonzero partials, the primal check 0 ≤ tol·0 fired at j=1 and
+    # the returned duals carried only the first-order term.
+    t = 0.1
+    A = [0.0 -0.5; 0.5 0.0]
+    x = [1.0, 0.0]
+    expected = exp(t * A) * x
+
+    # Zero primal, seeded duals (e.g. a state trajectory initialized at zero)
+    B = [ForwardDiff.Dual{ForwardDiff.Tag{Nothing,Float64}}(0.0, 1.0),
+         ForwardDiff.Dual{ForwardDiff.Tag{Nothing,Float64}}(0.0, 0.0)]
+    y = expv(t, A, B)
+    @test ForwardDiff.value.(y) ≈ zeros(2) atol = 1.0e-12
+    @test [ForwardDiff.partials(yi)[1] for yi in y] ≈ expected atol = 1.0e-12
+
+    # value-preserving sanity: nonzero primal remains exact
+    B2 = [ForwardDiff.Dual{ForwardDiff.Tag{Nothing,Float64}}(1.0, 1.0),
+          ForwardDiff.Dual{ForwardDiff.Tag{Nothing,Float64}}(0.0, 0.0)]
+    y2 = expv(t, A, B2)
+    @test ForwardDiff.value.(y2) ≈ expected atol = 1.0e-12
+    @test [ForwardDiff.partials(yi)[1] for yi in y2] ≈ expected atol = 1.0e-12
+end


### PR DESCRIPTION
Fixes #59.

## The bug
The convergence check in `expv_taylor` evaluates `norm_tail_tot ≤ tol * _opnormInf(F)` on stripped duals (`AD.primal_value`). With an AD type whose primal is zero but whose partials are not — e.g. a ForwardDiff `Dual` seeded at a zero state — every Taylor term has zero primal, the check degenerates to `0 ≤ tol·0`, and the series breaks at `j=1`. Values stay correct, but the returned partials carry only the first-order term, silently corrupting any Jacobian taken at a zero-valued vector (hit in practice differentiating bilinear quantum-control dynamics whose state trajectories start at zero).

Four-line repro in #59: partials `1.0` where the truth is `cos(0.05) ≈ 0.99875`.

## The fix
Treat an exactly-zero primal series as **not converged** and keep iterating up to the chosen degree — which already bounds the tail by the same `tol` criterion used to pick `degree_opt` in `parameters()`. Only the zero-primal path pays extra steps; every other path is byte-identical.

## Verification
- New regression test in `test/autodiff.jl`: zero-primal dual `B` → partials match `exp(tA)·x` exactly; nonzero-primal control unchanged.
- Full suite: **2307 passed, 0 failed** locally.
- End-to-end downstream: with this patch developed in, DirectTrajOpt/Piccolo's `BilinearIntegrator` analytic-vs-finite-difference Jacobian gates pass for zero-initialized variational trajectories (previously failing with the structured mismatch in harmoniqs/Piccolo.jl#307).